### PR TITLE
Fix support for export

### DIFF
--- a/src/donutState.js
+++ b/src/donutState.js
@@ -41,19 +41,12 @@ import { calculatePercentageValue, formatTotalSum } from "./utility";
 /**
  * Render the visualization
  * @param {Spotfire.Mod} mod API
- * @return {donutState}
+ * @param {Spotfire.DataView} dataView Data view
+ * @param {Spotfire.Size} size Size
+ * @param {Spotfire.RenderContext} context Context
+ * @return {donutState | undefined}
  */
-export async function createDonutState(mod) {
-    /**
-     * Initialize dataView, size, and context based on the mod API
-     * @param {Spotfire.DataView} dataView
-     * @param {Spotfire.Size} size
-     * @param {Spotfire.RenderContext} context
-     */
-    const dataView = await mod.visualization.data();
-    const size = await mod.windowSize();
-    const context = await mod.getRenderContext();
-
+export async function createDonutState(mod, dataView, size, context) {
     /**
      * Check for any errors.
      */

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -11,8 +11,10 @@ import { refreshCenterTextOnMouseLeave, refreshCenterTextOnMouseover, renderCent
  * @param {modProperty} modProperty
  * @param {boolean} circleTypeChanged
  * @param {boolean} labelsPositionChanged
+ * @param {boolean} interactive
  */
-export async function render(donutState, modProperty, circleTypeChanged, labelsPositionChanged) {
+export async function render(donutState, modProperty, circleTypeChanged, labelsPositionChanged, interactive) {
+    const animationDuration = interactive ? resources.animationDuration : 0;
     const width = donutState.size.width - resources.sizeModifier;
     const height = donutState.size.height - resources.sizeModifier;
 
@@ -106,13 +108,13 @@ export async function render(donutState, modProperty, circleTypeChanged, labelsP
     sectors
         .merge(newSectors)
         .transition()
-        .duration(resources.animationDuration)
+        .duration(animationDuration)
         .attr("value", (d) => d.data.absPercentage)
         .attr("fill", (d) => d.data.color)
         .attrTween("d", tweenArc)
         .attr("stroke", (d) => (d.data.markedRowCount() > 0 ? donutState.styles.fontColor : "none"));
 
-    sectors.exit().transition().duration(resources.animationDuration).attr("fill", "transparent").remove();
+    sectors.exit().transition().duration(animationDuration).attr("fill", "transparent").remove();
 
     function tweenArc(elem) {
         let prevValue = this.__prev || {};
@@ -165,12 +167,10 @@ export async function render(donutState, modProperty, circleTypeChanged, labelsP
     drawRectangularSelection(donutState, modProperty);
     applyHoverEffect(pie, donutState);
     addLabels(arc, pie, donutState, modProperty, circleTypeChanged, labelsPositionChanged);
-    drawOuterLinesForNegativeValues(pie, donutState, padding, svg);
+    drawOuterLinesForNegativeValues(pie, donutState, padding, svg, animationDuration);
     renderCenterText(donutState, radius, modProperty);
 
-    sectors.exit().transition().duration(resources.animationDuration).attr("fill", "transparent").remove();
-
-    donutState.context.signalRenderComplete();
+    sectors.exit().transition().duration(animationDuration).attr("fill", "transparent").remove();
 }
 
 /**
@@ -179,8 +179,9 @@ export async function render(donutState, modProperty, circleTypeChanged, labelsP
  * @param {donutState} donutState
  * @param {number} padding
  * @param {d3.svg} svg
+ * @param {number} animationDuration
  * */
-function drawOuterLinesForNegativeValues(pie, donutState, padding, svg) {
+function drawOuterLinesForNegativeValues(pie, donutState, padding, svg, animationDuration) {
     // Used for the outer side showing negative values
     let outerArcNegativeValues = d3
         .arc()
@@ -209,7 +210,7 @@ function drawOuterLinesForNegativeValues(pie, donutState, padding, svg) {
     // Define behavior on transition
     outerSectorsNegativeValues
         .transition()
-        .duration(resources.animationDuration)
+        .duration(animationDuration)
         .attrTween("d", function (d) {
             return function () {
                 return outerArcNegativeValues(d);
@@ -221,7 +222,7 @@ function drawOuterLinesForNegativeValues(pie, donutState, padding, svg) {
     outerSectorsNegativeValues
         .exit()
         .transition()
-        .duration(resources.animationDuration)
+        .duration(animationDuration)
         .attr("fill", "transparent")
         .remove();
 }

--- a/src/static/mod-manifest.json
+++ b/src/static/mod-manifest.json
@@ -1,6 +1,6 @@
 {
     "apiVersion": "1.3",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "name": "Donut Chart",
     "id": "donut-chart",
     "icon": "icon.svg",


### PR DESCRIPTION
This pull requests fixes a fix incorrect usages of the mods API. `mod.getRenderContext()` should be invoked synchronously when the mod is initialized. This was previously seen as a warning in the console. The other issue was that `context.signalRenderComplete()` was invoked before the visualization had finished rendering. This pull request removes the animation time when the mod is being exported.

A separate fix was to use the `dataView` object received as an argument to the subscribe loop instead of calling `await mod.visualization.data()` an extra time.